### PR TITLE
fix: 링크 경로 수정

### DIFF
--- a/server.js
+++ b/server.js
@@ -56,7 +56,7 @@ app.get('*', async (req, res) => {
       files.forEach(file => {
         const relativePath = path.relative(rootDir, file.path);
         if (file.isDirectory) {
-          html += `<li><a href="${relativePath}/">${file.name}/</a></li>`;
+          html += `<li><a href="/${relativePath}/">${file.name}/</a></li>`;
         } else {
           html += `<li><a href="/file/${relativePath}">${file.name}</a></li>`;
         }


### PR DESCRIPTION
파일 목록에서 링크 경로가 잘못되어
수정함

- 루트 경로를 포함하도록 변경
- 이전에는 상대 경로만 사용해서 파일을
  찾을 수 없었음
